### PR TITLE
update(ci): codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # Maintainers
-* @danielRep @sandro2pinto
+* @danielRep @josecm
+
+source/development/doc_guidelines.rst @danielRep
+
+source/development/contributing.rst @josecm
+source/development/misra.rst @josecm


### PR DESCRIPTION
@josecm replaces @sandro2pinto as a maintainer and specific files are assigned only to the initial author.

Signed-off-by: Jose Martins <josemartins90@gmail.com>