### PR TITLE
update(gitlint): add update type to the gitlint cfg file

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -116,6 +116,6 @@ contrib=contrib-title-conventional-commits,CC1
 # You need to explicitly enable them one-by-one by adding them to the "contrib" option
 # under [general] section above.
 [contrib-title-conventional-commits]
-types = fix,ref,feat,build,doc,perf,wip,exp,test,ci,style
+types = fix,ref,feat,build,doc,perf,wip,exp,test,opt,ci,style,update
 
 [contrib-body-requires-signed-off-by]


### PR DESCRIPTION
This PR changes the type variable in the gitlint configuration file to enable the `update` and `opt` type as decribed here (4c208e8fc39b47491a4cbc949fbe25398fbab03a). 