### PR TITLE
feat/glossary: add a glossary to the documentation

### DIFF
--- a/source/development/ci_pipeline.rst
+++ b/source/development/ci_pipeline.rst
@@ -1,2 +1,4 @@
+.. _ci_pipeline:
+
 Continuous Integration
 ======================

--- a/source/development/contributing.rst
+++ b/source/development/contributing.rst
@@ -6,8 +6,8 @@ Contributing
 The development of Bao projects' components uses the Github ecosystem for
 contributions, code review, bug reporting, discussion of ideas or any other
 community development, or project management activities. Therefore, every
-contributor should first create a Github account, if they do not have one
-already.
+:term:`contributor` should first create a Github account, if they do not have
+one already.
 
 If you plan to contribute a significant portion of code, such as an
 architecture or platform port, a new subsystem or feature, please consider
@@ -17,6 +17,8 @@ debated among the community and **maintainers**.
 We also recommend you to read our :ref:`licensing terms and the DCO
 claim <licensing>` before making any contribution.
 
+.. _contrib_roles:
+
 Roles
 -----
 
@@ -24,8 +26,8 @@ The project defines three essential types of roles in the development and
 contribution process: **developer**, **code owner**, and **maintainer**.
 
 A **developer** can be internal (if they are part of the project's core team)
-or are an outside contributor. Anyone that contributes in any way to the
-project (e.g., code, reviews, issues, etc) is assigned to this role.
+or are an outside :term:`contributor`. Anyone that contributes in any way to
+the project (e.g., code, reviews, issues, etc) is assigned to this role.
 
 A **code owner** must either be part of the core team or someone invited and
 marked as an outside collaborator by a **maintainer**. He is responsible for
@@ -47,7 +49,7 @@ repository management tasks which include:
   file<github_files>`;
 * keep an updated :ref:`list of authors and contributors<github_files>`;
 * coordinating and moderating code reviews;
-* final approval and merging of pull-requests (PR);
+* final approval and merging of pull-requests (:term:`PR`);
 * coordinating, moderating and closing of issues;
 * setting up the repository's :ref:`CI pipeline via Github
   Actions<github_actions>`;
@@ -67,7 +69,7 @@ Contribution Workflow
 
 The project's development flow for all repositories is centered around the
 ``main`` branch. Any code contribution, be it internal or external, takes the
-form of a Github PR to the ``main`` branch. The ``main`` branch is then
+form of a Github :term:`PR` to the ``main`` branch. The ``main`` branch is then
 tagged periodically according to the defined :ref:`versioning
 scheme<versioning>`.
 
@@ -91,7 +93,7 @@ branches.
 Submitting Commits
 ******************
 
-If you are an external contributor or do not have write permissions to the
+If you are an external :term:`contributor` or do not have write permissions to the
 repository you wish to contribute to, first of all, you should `fork that
 repository <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_.
 If you do have write privileges over the original repository, you carry out the
@@ -117,26 +119,26 @@ development directly on it. Follow these steps:
       commits to the existing pull request. If existing commits need to be
       modified, rewrite the history and force push them to maintain a clean
       linear history;
-    * if the **reviewers** are taking too long, try contacting the PR
+    * if the **reviewers** are taking too long, try contacting the :term:`PR`
       assignee.
 
 Review Assignment
 *****************
 
-A PR must have at least one assignee and be approved by at least two
+A :term:`PR` must have at least one assignee and be approved by at least two
 **reviewers**. The assignee must be a **maintainer** which will be responsible
-for getting the PR through, having the ultimate say on its acceptance and that
-must carry out the final merge. **Maintainers** must coordinate to choose among
-them the assignee as PRs arrive. One of the **reviewers** must also
-be a **maintainer** (which can coincide with the assignee).
+for getting the :term:`PR` through, having the ultimate say on its acceptance
+and that must carry out the final merge. **Maintainers** must coordinate to
+choose among them the assignee as PRs arrive. One of the **reviewers** must
+also be a **maintainer** (which can coincide with the assignee).
 
 If a **code owner** exist for the code being submitted, at least one of them
-(for each of the files/subsystems) must review the code. **Code owners**
-will be automatically assigned as **reviewers** if the **maintainers** are
-correctly managing the :ref:`.CODEOWNERS file<github_files>`. If there aren't
-enough **reviewers**, the assignee is responsible for appointing a second
-**reviewer**. Preferably, a project's internal contributor. They might also
-require and invite more **reviewers** if there is no consensus.
+(for each of the files/subsystems) must review the code. **Code owners** will
+be automatically assigned as **reviewers** if the **maintainers** are correctly
+managing the :ref:`.CODEOWNERS file<github_files>`. If there are not enough
+**reviewers**, the assignee is responsible for appointing a second
+**reviewer**. Preferably, a project's internal :term:`contributor`. They might
+also require and invite more **reviewers** if there is no consensus.
 
 Review Guide
 ************
@@ -149,7 +151,7 @@ tools.
 The following are some tips all **reviewers** should take into account:
 
 * Make sure the code is readable, well commented (includes doxygen comments),
-  and the PR provide the appropriate/necessary documentation;
+  and the :term:`PR` provide the appropriate/necessary documentation;
 * The code follows the project's :ref:`coding guidelines<coding_guidelines>` as
   much as possible, especially those not automatically checked such as:
 
@@ -157,13 +159,13 @@ The following are some tips all **reviewers** should take into account:
       architecture specific files in the *arch* directory);
     * naming conventions for files, functions, variables, types, etc.
 
-* The PR complies with all the relevant standards mandated for the specific
-  language or repo in question (e.g. :ref:`MISRA<misra>`);
-* There are no obscure binary blobs included in the PR;
-* Understand the design and implementation decisions behind the PR; Try to
-  imagine how you'd go about implementing the same functionality, and
-  engage in discussion when it does not match the proposed approach.
-  Discuss the trade-offs of the various approaches.
+* The :term:`PR` complies with all the relevant standards mandated for the
+  specific language or repo in question (e.g. :ref:`MISRA<misra>`);
+* There are no obscure binary blobs included in the :term:`PR`;
+* Understand the design and implementation decisions behind the :term:`PR`; Try
+  to imagine how you'd go about implementing the same functionality, and engage
+  in discussion when it does not match the proposed approach. Discuss the
+  trade-offs of the various approaches.
 * Have a holistic view of the code in mind:
 
     * how do the modifications affect other subsystems and the
@@ -180,20 +182,21 @@ The following are some tips all **reviewers** should take into account:
   tags are correctly added or updated;
 
 Review the code as much as possible by opening discussions and adding comments
-inline in the ``Files Changed`` tab of the PR, and opening a review. When you
-are done click the ``Finish Review`` button and submit the review either by
-only commenting or requesting explicit changes. As the contributor addresses
-your concerns mark each item as resolved. When you are happy with the current
-state with the PR and agree it should be merged, add a final review
-with an explicit approval. Beware there might still be new commits after you
-have approved the PR and you might need or be asked to review it again.
+inline in the ``Files Changed`` tab of the :term:`PR`, and opening a review.
+When you are done click the ``Finish Review`` button and submit the review
+either by only commenting or requesting explicit changes. As the
+:term:`contributor` addresses your concerns mark each item as resolved. When
+you are happy with the current state with the :term:`PR` and agree it should be
+merged, add a final review with an explicit approval. Beware there might still
+be new commits after you have approved the :term:`PR` and you might need or be
+asked to review it again.
 
 Finally, although obvious, self-reviewing is prohibited.
 
 Final Approval and Merging
 **************************
 
-The final approval of the PR to ``main`` must be carried out by a
+The final approval of the :term:`PR` to ``main`` must be carried out by a
 **maintainer**. They should verify the following checklist, although some of it
 might be automatically checked and enforced by GitHub:
 
@@ -203,15 +206,15 @@ might be automatically checked and enforced by GitHub:
 * passes all :ref:`CI pipeline <ci>` checks;
 * can be rebased on ``main`` without any conflict;
 
-The **maintainer** shall have as the main objective when integrating the PR to
-maintain a linear git history. Therefore, it should preferably perform either a
-rebase of the PR branch on ``main`` (or fast-forward merge if possible) or
-perform a squash merge if they deem necessary.
+The **maintainer** shall have as the main objective when integrating the
+:term:`PR` to maintain a linear git history. Therefore, it should preferably
+perform either a rebase of the :term:`PR` branch on ``main`` (or fast-forward
+merge if possible) or perform a squash merge if they deem necessary.
 
-If the PR originates from an internal topic branch, the branch should be
-deleted.
+If the :term:`PR` originates from an internal topic branch, the branch should
+be deleted.
 
-Finally, the **maintainer** should update any contributor,
+Finally, the **maintainer** should update any :term:`contributor`,
 :ref:`author and/or code owner files<github_files>`, especially when new files
 are created.
 
@@ -221,7 +224,7 @@ Commit and Pull-Request Guidelines
 ----------------------------------
 
 All contributions must be submitted via Github PRs. You should ensure
-that all commits within the PR:
+that all commits within the :term:`PR`:
 
 * have messages that follow the :ref:`conventional commit style<>`
 * introduce small, self-contained logical units of modifications/extensions
@@ -230,7 +233,8 @@ that all commits within the PR:
 * are logically related (unrelated modifications or fixes must be addressed
   in a separate ``branch/pull-request``);
 * follow a logical order. That is, a commit that has a dependence on the
-  modifications by a different commit of the same PR, is after the former.
+  modifications by a different commit of the same :term:`PR`, is after the
+  former.
 * adhere to the project's :ref:`coding guidelines<>` for the targeted
   languages;
 * tag the necessary :ref:`requirements<>`;
@@ -305,7 +309,7 @@ The ``<footer>`` consists of a list of optional references when the commit:
 * ``<ref-misra>``: introduces a misra deviation (misra deviation or permit ID)
 * ``<ref-req>``: implements a given requirement (requirement ID)
 * ``<sign-off>``: a sign-off message that attests that he agrees with the
-  contributor adheres :ref:`dco` (see :ref:`commit_signoff`)
+  :term:`contributor` adheres :ref:`dco` (see :ref:`commit_signoff`)
 
 **Commit Example:**
 
@@ -420,18 +424,19 @@ their contributors in to files at the repo's top-level:
   contribution to the system, such as implementing a new feature, subsystem,
   port to a new architecture/platform, and the like.
 
-These files must list contributor/author per line, preferably in the format
+These files must list :term:`contributor`/author per line, preferably in the
+format
 
 .. code-block:: none
 
     Contributor's Name <contributors@email.com>
 
 using the name and e-mail associated with their Github accounts and commits.
-However, if some contributor requests to be listed in another format,
+However, if some :term:`contributor` requests to be listed in another format,
 (e.g. using some alias), we can also accommodate it.
 
-If a contributor does not wish to be listed or have any of their information
-removed, maintainers must fulfill their request.
+If a :term:`contributor` does not wish to be listed or have any of their
+information removed, maintainers must fulfill their request.
 
 Preferably, these files should list the contributors/authors in a chronologic
 order regarding their first contribution. That means each time a new person
@@ -474,7 +479,8 @@ GitHub Actions. Specifically, by adding workflow yaml files to the
 ``.github/workflows`` directory. The :ref:`CI repository <ci_repo>` contains a
 number of templates as well as further instructions on how to set it up.
 
-Here are a few workflows a **maintainer** should add to the repository's CI:
+Here are a few workflows a **maintainer** should add to the repository's
+:term:`CI`:
 
 * commit message linting: apply gitlint to verify all the PRs'
   commit messages follow the conventional commit style;
@@ -510,12 +516,12 @@ The following are the allowed types for topic branches and commits:
 * ``exp``: a code change that is purely experimental for now
 * ``test``: adding missing tests or correcting existing ones
 * ``opt``: modifications pertaining only to optimizations
-* ``ci``: changes to the CI configuration files and scripts [#]_
+* ``ci``: changes to the :term:`CI` configuration files and scripts [#]_
 * ``style``: changes that do not affect the meaning of the code (formatting,
   typos, naming, etc.)
 * ``update``: changes that brings a feature, setup, or configuration up to date
   by adding new or updated information (e.g., updating a version, adding a new
-  item to a list, updating CODEOWNERS, bumping the CI repo)
+  item to a list, updating CODEOWNERS, bumping the :term:`CI` repo)
 
 .. [#] Cannot be used in the `bao-docs <https://github.com/bao-project/bao-docs>`_ repo.
 .. [#] Cannot be used in the `bao-ci <https://github.com/bao-project/bao-ci>`_  repo.

--- a/source/development/doc_guidelines.rst
+++ b/source/development/doc_guidelines.rst
@@ -538,8 +538,9 @@ which transforms ``term1`` in a hyperlink to its glossary entry.
     - While writing the documentation, a best-effort **should** be in-place to
       guarantee that each new term (i.e., abbreviations, siglums, bao's
       architectural components/services/entities) are added to the glossary.
-    - If a new term is added to the glossary, you **must** mark it with the
-      ``:term:`` keyword to created a link to the glossary entry. However, this
-      should be avoided if the term has a dedicated file documenting it
-      (e.g., :ref:`CI <ci_pipeline>`, :ref:`MISRA <misra>`). Use explicit
-      referencing instead. Notwithstanding, add the term to the glossary.
+    - If a new term is added to the glossary, you **must** search for each
+      reference in all other documents and mark it with the ``:term:`` keyword
+      to created a link to the glossary entry. However, this should be
+      avoided if the term has a dedicated file documenting it (e.g.,
+      :ref:`CI <ci_pipeline>`, :ref:`MISRA <misra>`). Use explicit referencing
+      instead. Notwithstanding, add the term to the glossary.

--- a/source/development/misra.rst
+++ b/source/development/misra.rst
@@ -3,22 +3,22 @@
 MISRA Compliance
 ================
 
-The project aims to comply with the MISRA C:2012 coding guidelines in all C
-code across all repositories. All submitted code will be checked for MISRA
-violations following the :ref:`Guideline Enforcement Plan <misra_gep>` and the
-:ref:`Guideline Requalification Plan <misra_grp>` using automated checker tools
-in the :ref:`CI pipeline <ci>`. Developers should continuously check for MISRA
-violations by :ref:`running the checker tools locally<misra_check_locally>` at
-each commit. Any violation identified in the submitted code must be justifiable
-and duly :ref:`deviated<deviations>`. These processes must be properly
-documented, peer-reviewed, and authorized according to the project's
-:ref:`contribution process <contributing>` and the guidance provided by the
-official `MISRA Compliance:2020 document
+The project aims to comply with the :term:`MISRA` C:2012 coding guidelines in
+all C code across all repositories. All submitted code will be checked for
+:term:`MISRA` violations following the :ref:`Guideline Enforcement Plan
+<misra_gep>` and the :ref:`Guideline Requalification Plan <misra_grp>` using
+automated checker tools in the :ref:`CI pipeline <ci>`. Developers should
+continuously check for :term:`MISRA` violations by :ref:`running the checker
+tools locally<misra_check_locally>` at each commit. Any violation identified in
+the submitted code must be justifiable and duly :ref:`deviated<deviations>`.
+These processes must be properly documented, peer-reviewed, and authorized
+according to the project's :ref:`contribution process <contributing>` and the
+guidance provided by the official `MISRA Compliance:2020 document
 <https://www.misra.org.uk/app/uploads/2021/06/MISRA-Compliance-2020.pdf>`_.
 
-Every developer, reviewer, or maintainer should familiarize themselves with,
-first and foremost, the guidelines themselves, and secondly, the processes
-described in this document.
+Every :term:`developer`, reviewer, or :term:`maintainer` should
+familiarize themselves with, first and foremost, the guidelines themselves, and
+secondly, the processes described in this document.
 
 Each repository in the project might abide by the guidelines with varying
 degrees of fidelity. Each will have its independent :ref:`MISRA
@@ -37,26 +37,26 @@ shop <https://www.misra.org.uk/shop/>`_.
 Guideline Enforcement Plan (GEP) and Checker Tool
 --------------------------------------------------
 
-The Guideline Enforcement Plan (GEP) describes, for each MISRA guideline, what
-are the checker tools or processes that are being used to enforce it. For each
-tool, a specific version and configuration information must be specified. Each
-process, such as manual review, shall provide instructions and
-checklists to aid reviewers. Ideally, the GEP should also prescribe measures on
-how to detect and deal with each :ref:`undecidable
+The Guideline Enforcement Plan (GEP) describes, for each :term:`MISRA`
+guideline, what are the checker tools or processes that are being used to
+enforce it. For each tool, a specific version and configuration information
+must be specified. Each process, such as manual review, shall provide
+instructions and checklists to aid reviewers. Ideally, the GEP should also
+prescribe measures on how to detect and deal with each :ref:`undecidable
 guidelines<misra_undecidable_false_positive>`. :ref:`Each
 repository<misra_artefacts>` must provide a GEP in a CSV format. The base GEP
 is provided in the :ref:`CI repository <ci_repo>`.
 
 
-The main tool used by the project to check for MISRA guideline violations is
-`cppcheck <https://cppcheck.sourceforge.io/>`_. cppcheck is a completely free
-and open-source static analysis tool that provides a python-based add-on
-implementing the MISRA checks. The project's core team may use proprietary
-tools to periodically scan the code for cppcheck false positives or negatives,
-as well as providing an overall higher degree of confidence that the guidelines
-are being followed. However, the use of these tools will not be available to
-external contributors, and the output of such tools will not be openly
-published.
+The main tool used by the project to check for :term:`MISRA` guideline
+violations is `cppcheck <https://cppcheck.sourceforge.io/>`_. cppcheck is a
+completely free and open-source static analysis tool that provides a
+python-based add-on implementing the :term:`MISRA` checks. The project's core
+team may use proprietary tools to periodically scan the code for cppcheck false
+positives or negatives, as well as providing an overall higher degree of
+confidence that the guidelines are being followed. However, the use of these
+tools will not be available to external contributors, and the output of such
+tools will not be openly published.
 
 
 .. _misra_grp:
@@ -64,10 +64,10 @@ published.
 Rule Categories and Guideline Requalification Plan (GRP)
 ------------------------------------------------------------
 
-MISRA rules can be categorized as mandatory, required, or advisory. This
-categorization defines whether or not a :ref:`deviation<deviations>` is allowed
-and, in case it is, if a :ref:`deviation record or permit<deviation_records>`
-is required:
+:term:`MISRA` rules can be categorized as mandatory, required, or advisory.
+This categorization defines whether or not a :ref:`deviation<deviations>` is
+allowed and, in case it is, if a :ref:`deviation record or
+permit<deviation_records>` is required:
 
 * **Mandatory**: a deviation is never allowed;
 
@@ -127,28 +127,30 @@ Deviations
 ----------
 
 All new :ref:`code submissions via a GitHub pull-requests <contributing>`, will
-be subject to the automatic checking of MISRA compliance by the :ref:`CI
-pipeline <ci>`. Ideally, the pull-request should not introduce any new MISRA
-violations. Developers should always strive to follow the MISRA coding
-guidelines. However, they may conclude that a violation is unavoidable and
-justifiable according to at least one of the :ref:`deviation reasons
-<deviation_reasons>`. If so, developers must document and request the
+be subject to the automatic checking of :term:`MISRA` compliance by the
+:ref:`CI pipeline <ci>`. Ideally, the pull-request should not introduce any new
+:term:`MISRA` violations. Developers should always strive to follow the
+:term:`MISRA` coding guidelines. However, they may conclude that a violation is
+unavoidable and justifiable according to at least one of the :ref:`deviation
+reasons <deviation_reasons>`. If so, developers must document and request the
 introduction of the violation in the code base, which will be subject to the
 approval of a code reviewer. These approved violations are called deviations.
-To introduce a deviation, a developer must follow the :ref:`deviation procedure
-<deviation_procedure>` which include providing a :ref:`deviation record
-<deviation_records>`, :ref:`annotate<deviation_annotations>` all violations,
-and being explicitly approved by :ref:`MISRA managers<misra_manager>`.
+To introduce a deviation, a :term:`developer` must follow the :ref:`deviation
+procedure <deviation_procedure>` which include providing a :ref:`deviation
+record <deviation_records>`, :ref:`annotate<deviation_annotations>` all
+violations, and being explicitly approved by :ref:`MISRA
+managers<misra_manager>`.
 
 .. _deviation_reasons:
 
 Deviation Reasons
 *****************
 
-A deviation must not be just a convenience for the developer. Reasonable coding
-alternatives that would avoid the deviation should always be considered. If
-none is found, the developer may come to the conclusion that introducing a
-violation is justifiable mainly due to the following reasons:
+A deviation must not be just a convenience for the :term:`developer`.
+Reasonable coding alternatives that would avoid the deviation should always be
+considered. If none is found, the :term:`developer` may come to the conclusion
+that introducing a violation is justifiable mainly due to the following
+reasons:
 
 * **Code quality**. Not introducing the violation would impact code quality
   metrics such as the ones defined by Section 4.5 of ISO/IEC 25010. For
@@ -168,7 +170,7 @@ violation is justifiable mainly due to the following reasons:
   constitutes a bottleneck on a critical path.
 
 * **Access to hardware**, i.e., using ISA or MMIO facilities. Not introducing
-  the violation would inhibit the developer to perform an operation, to
+  the violation would inhibit the :term:`developer` to perform an operation, to
   implement a given functionality or important bottleneck optimization as
   mentioned above.
 
@@ -181,16 +183,16 @@ violation is justifiable mainly due to the following reasons:
   manager<misra_manager>`.
 
 * **Implementation or compliance of standards**. If it would preclude the
-  developer from implementing, using, or following a standard or externally
-  defined API.
+  :term:`developer` from implementing, using, or following a standard or
+  externally defined API.
 
 .. _deviation_procedure:
 
 Deviation Procedure
 *******************
 
-A developer should take the following steps when introducing a new MISRA
-deviation:
+A :term:`developer` should take the following steps when introducing a new
+:term:`MISRA` deviation:
 
     1. Check if the deviation falls under the scope of any of the existing
        :ref:`deviation permits<deviation_records>`;
@@ -232,17 +234,17 @@ When a pull-request introduces new violations, the reviewers must:
 Deviation annotations
 *********************
 
-Deviation annotations are placed in comments preceding the code
-incurring the violation. Their main role is to identify the code locations
-related to a given deviation record or permit, as well as suppress violation
-diagnostics issued by the checker tools. A deviation annotation follows a
-single-line pre-defined format that contains the identifier of MISRA rule that
-is being broken as well the deviation record/permit identifier. It follows the
-base format :code:`HEADER:GUIDELINE:RECORD/PERMIT`. In its simplest format, it
-will flag a deviation in the next line. For example, :code:`MISRADEV:R2.5:MDR2`
-signals a violation of rule 2.5 in the following line, backed by deviation
-record MDR2. However, to allow more flexible ranges of code, there are three
-classes of deviation annotations, depending on the used header:
+Deviation annotations are placed in comments preceding the code incurring the
+violation. Their main role is to identify the code locations related to a given
+deviation record or permit, as well as suppress violation diagnostics issued by
+the checker tools. A deviation annotation follows a single-line pre-defined
+format that contains the identifier of :term:`MISRA` rule that is being broken
+as well the deviation record/permit identifier. It follows the base format
+:code:`HEADER:GUIDELINE:RECORD/PERMIT`. In its simplest format, it will flag a
+deviation in the next line. For example, :code:`MISRADEV:R2.5:MDR2` signals a
+violation of rule 2.5 in the following line, backed by deviation record MDR2.
+However, to allow more flexible ranges of code, there are three classes of
+deviation annotations, depending on the used header:
 
     * **single-line**: as described before, its the header is simply
       :code:`MISRADEV`. It should be placed in a line by itself to flag a
@@ -390,7 +392,7 @@ to be supported by the permit. Permits must follow this ``yaml`` template:
         - ...
 
 When writing a deviation record that fits a pre-existing deviation permit, a
-developer only needs to identify the deviation permit and justify why the
+:term:`developer` only needs to identify the deviation permit and justify why the
 deviation meets the permit requirements. The reviewer's job is also verifying
 the justifications for meeting the permit's requirements are valid, with no
 need to make sure the justification itself is valid. When this is the case, the
@@ -400,8 +402,8 @@ deviation can be accepted without the explicit acknowledgement of the
 Whenever reviewers or maintainers identify that a relatively significant group
 of existing deviations have a common ground cause and justification, or if they
 predict that a guideline will be frequently deviated for a given use-case, they
-should submit the proposal for the introduction of a new MISRA permit to the
-repository :ref:`MISRA manager<misra_manager>`.
+should submit the proposal for the introduction of a new :term:`MISRA` permit
+to the repository :ref:`MISRA manager<misra_manager>`.
 
 Dealing with Pre-existing Violations
 ------------------------------------
@@ -410,7 +412,7 @@ Pre-existing violations might be encountered in the existing code and not
 necessarily be introduced by a new pull-request. This might happen, for
 example, whenever the checker tools are updated or reconfigured.
 
-When pre-existing violations are detected, the repository maintainer is
+When pre-existing violations are detected, the repository :term:`maintainer` is
 responsible for either modify the code to remove the violations or introduce
 new deviations following the :ref:`deviation procedure<deviation_procedure>`.
 
@@ -418,13 +420,14 @@ False Positive Diagnostics
 --------------------------
 
 A checker tool may wrongly identify a rule violation. These are called false
-positive diagnostics. If a contributor by itself, or during a discussion in the
-reviewing process, concludes that one of the checker tools is issuing a false
-positive, they should notify the :ref:`MISRA managers<misra_manager>` who
-shall issue a bug ticket with the checker provider or developers. Meanwhile,
-the false positive can be tagged with a special deviation annotation with the
-format :code:`MISRAFP:RULE:` while waiting for the issue to be solved by the
-tool providers, and remove it as soon as the issue is fixed. For example:
+positive diagnostics. If a :term:`contributor` by itself, or during a
+discussion in the reviewing process, concludes that one of the checker tools is
+issuing a false positive, they should notify the :ref:`MISRA
+managers<misra_manager>` who shall issue a bug ticket with the checker provider
+or developers. Meanwhile, the false positive can be tagged with a special
+deviation annotation with the format :code:`MISRAFP:RULE:` while waiting for
+the issue to be solved by the tool providers, and remove it as soon as the
+issue is fixed. For example:
 
     .. code-block:: c
 
@@ -448,8 +451,9 @@ managers<misra_manager>` who shall forward it to the tool's providers.
 Repository MISRA Artefacts
 --------------------------
 
-Each repository subject to MISRA compliance check shall have a dedicated
-``misra`` directory at the top level. The ``misra`` directory shall contain:
+Each repository subject to :term:`MISRA` compliance check shall have a
+dedicated ``misra`` directory at the top level. The ``misra`` directory shall
+contain:
 
     * the :ref:`GEP<misra_gep>` in CSV format
     * the :ref:`GRP<misra_grp>` in CSV format
@@ -467,8 +471,9 @@ MISRA managers
 --------------
 
 On top of the roles described in :ref:`ci`, every repository shall be assigned
-at least one MISRA manager responsible for enforcing the processes described in
-this document and guaranteeing the `MISRA compliance best practices
+at least one :term:`MISRA` manager responsible for enforcing the processes
+described in this document and guaranteeing the `MISRA compliance best
+practices
 <https://www.misra.org.uk/app/uploads/2021/06/MISRA-Compliance-2020.pdf>`_ are
 being followed as best as possible. Therefore, they will have the ultimate say
 in the decisions taken regarding the guidelines. Their responsibilities
@@ -493,8 +498,8 @@ Running the MISRA Checker Locally
 ---------------------------------
 
 Every project shall instantiate the :ref:`CI<ci_repo>` :code:`misra-check` Make
-rule that takes care of running all the necessary MISRA checks. For example,
-for checking compliance for the *qemu-aarch64-virt* platform:
+rule that takes care of running all the necessary :term:`MISRA` checks. For
+example, for checking compliance for the *qemu-aarch64-virt* platform:
 
   .. code-block:: shell
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -1,0 +1,35 @@
+.. _glossary:
+
+Glossary
+========
+
+.. glossary::
+    :sorted:
+
+    PR
+        Pull-Request: changes to be pushed into a branch of a repository. More
+        information :ref:`here <contributing>`.
+
+    CI
+        Continuous Integration: process that automates the integration of
+        new changes to the repositories. More information
+        :ref:`here <ci_pipeline>`.
+
+    MISRA
+        Set of software development guidelines for the C programming language
+        developed by The MISRA Consortium and followed by the Bao project. More
+        information :ref:`here <misra>`
+
+    maintainer
+        Top-level role in the administration of a repository. More information
+        :ref:`here <contrib_roles>`.
+
+    contributor
+        Internal or external developer that in any way contributes to the project.
+        More information :ref:`here <contrib_roles>`.
+
+    code owner
+        High-level role in the administration of a repository, marked and
+        invited by a maintainer to oversee the development of one or multiple
+        subsystems in a repository. More information
+        :ref:`here <contrib_roles>`.

--- a/source/index.rst
+++ b/source/index.rst
@@ -14,5 +14,6 @@ Bao Documentation
    user_manual/index
    development/index
    internals/index
+   glossary
 
 

--- a/source/spelling_wordlist.txt
+++ b/source/spelling_wordlist.txt
@@ -54,3 +54,5 @@ specificities
 chronologic
 reST
 syntaxes
+siglums
+PRs


### PR DESCRIPTION
This PR adds a global glossary for the overall documentation. This implied two extra changes:
1. Restructure the documentation guidelines to better split the information (i.e., reST syntax, checkers, glossary). The internal index was getting to large and the information without any particular group order.
2. Specify the use of the glossary and some guidelines in the `doc_guidelines`
3. Add a glossary file to the top-level directory of source, that will hold all terms that need a definition
4. Identify some terms throughout the current documentation and add the term and definition to the glossary