### PR TITLE
ci(gitlint): change types of commits to meet repo specifities

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -116,6 +116,6 @@ contrib=contrib-title-conventional-commits,CC1
 # You need to explicitly enable them one-by-one by adding them to the "contrib" option
 # under [general] section above.
 [contrib-title-conventional-commits]
-types = fix,ref,feat,build,doc,perf,wip,exp,test,opt,ci,style,update
+types = fix,ref,feat,build,wip,exp,ci,style,update
 
 [contrib-body-requires-signed-off-by]


### PR DESCRIPTION
Remove unnecessary gitlint types of commits for bao-docs repo.