### PR TITLE
Fix/sphinxcontrib.spelling cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W
+SPHINXOPTS    ?= -W -a
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
This pull request provides a more portable behavior for the sphinxcontrib.spelling extension by forcing the outputs to be generated every time instead of being cached, which could result in errors if the tool is used in different projects or folders.