### PR TITLE
update(contr): add note regarding chained PRs

### DIFF
--- a/source/development/contributing.rst
+++ b/source/development/contributing.rst
@@ -100,6 +100,14 @@ If you do have write privileges over the original repository, you carry out the
 development directly on it. Follow these steps:
 
 1. Create a topic branch from the ``main`` branch;
+
+.. note::
+
+    It is possible to create a topic branch based on another branch. This may
+    be necessary if the changes are dependent on that specific branch.
+    However, if this occurs during **step 4** of the process, it is mandatory
+    to make the target branch the one that the new branch is based on.
+
 2. Make all the necessary commits and push your work to your remote fork.
    Make sure that all the introduced commits and the overall branch follow
    the :ref:`commit and PR guidelines<commit_guidelines>`;


### PR DESCRIPTION
## PR Description

Small update to add a note regarding the possibility of a contributor opening a PR based on another branch that create a chain of PRs.

### Type of change

- **update**: changes that brings a feature, setup, or configuration up to date by adding new or updated information
  - Logical unit: contributing guidelines

## Checklist:

- [x] The changes follows the documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst).
- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
