### PR TITLE
ref/glossary: capitalization terms

### DIFF
--- a/source/development/doc_guidelines.rst
+++ b/source/development/doc_guidelines.rst
@@ -517,8 +517,8 @@ Throughout Bao's documentation we try to maintain an updated and consolidated
 global glossary, that references terms to their definitions. The
 :ref:`glossary` is located in the ``source`` top-level directory, under the
 file ``glossary.rst``. Each glossary entry, must be written as a definition
-list, with a term (in upper-case), followed by a single-line indented
-definition (see the code block below to verify the format).
+list, with a capitalized term, followed by a single-line indented definition
+(see the code block below to verify the format).
 
 .. code-block:: rest
 

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -20,16 +20,16 @@ Glossary
         developed by The MISRA Consortium and followed by the Bao project. More
         information :ref:`here <misra>`
 
-    maintainer
+    Maintainer
         Top-level role in the administration of a repository. More information
         :ref:`here <contrib_roles>`.
 
-    developer
-    contributor
+    Developer
+    Contributor
         Internal or external developer that in any way contributes to the project.
         More information :ref:`here <contrib_roles>`.
 
-    code owner
+    Code Owner
         High-level role in the administration of a repository, marked and
         invited by a maintainer to oversee the development of one or multiple
         subsystems in a repository. More information


### PR DESCRIPTION
## PR Description

This PR refactors the documentation guidelines to mention that glossary terms should be capitalize. Suggested in PR #47 .

### Type of change

- **ref**: refactoring of a code/doc block
  - Logical unit: <doc_guidelines>

## Checklist:

- [x] The changes follows the documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst).
- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
