### PR TITLE
ref(makefile): remove unnecessary spelling/html targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,4 @@ format:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-spelling:
-	@$(SPHINXBUILD) -M spelling "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-ci: format spelling
-	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+ci: format html spelling


### PR DESCRIPTION
## PR Description

I noticed that the Makefile was using a catch-all target, therefore the spelling and html explicit target are unnecessary. 

### Type of change

- **ref**: refactoring of a code/doc block
  - Logical unit: Makefile

## Checklist:

- [x] The changes follows the documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst).
- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
