### PR TITLE
ci(codeowners): add @miguelafsilva5 as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Maintainers
-* @danielRep @josecm
+* @danielRep @josecm @miguelafsilva5
 
 source/development/doc_guidelines.rst @danielRep
 


### PR DESCRIPTION
## PR Description

As @miguelafsilva5 was elected maintainer for the bao-docs repository, I am adding him to the codeowners so that he is an automatic reviewer for future PRs.