### PR TITLE
ci(codeowners): requirements doc codeowner to @DavidMCerdeira

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,5 @@ source/development/doc_guidelines.rst @danielRep
 
 source/development/contributing.rst @josecm
 source/development/misra.rst @josecm
+
+source/requirements @DavidMCerdeira


### PR DESCRIPTION
## PR Description

As @DavidMCerdeira is the author of the requirements documentation, he should be marked as code owner so that he is automatically marked as reviewer for PRs that modify it.
