### PR TITLE
Introduce C coding guidelines documentation

### DIFF
--- a/source/development/coding_style.rst
+++ b/source/development/coding_style.rst
@@ -3,11 +3,69 @@
 Coding Guidelines
 =================
 
-This document specifies a set of coding guidelines including code style,
-formatting and file structuring and organization that shall be applied when
-contributing code to the Bao project. We strive so that most of the guidelines
-can be automatically checked or even enforced by the CI pipeline and try to
-minimize guidelines which can not be automatically addressed. However, in the
-few instances this is not possible, responsibility falls upon code reviewers
-and maintainers to uphold these guidelines are applied as much as possible.
+This document specifies a set of coding guidelines, including code style,
+formatting, file structuring and organization that shall be applied when
+contributing code to the Bao project. We strive to ensure that most of the
+guidelines can be automatically checked or even enforced by the CI pipeline and
+minimize guidelines that can not be automatically addressed. In cases where it
+is not feasible to automatically enforce certain guidelines, the responsibility
+lies with the code reviewers and maintainers to ensure that these guidelines
+are adhered to as closely as possible.
 
+C Language
+----------
+
+The coding style and guidelines for C development are heavily influenced and
+constrained by the MISRA C:2012 guidelines, which should take precedence above
+all others in this document or elsewhere.
+
+Compiler Configuration
+**********************
+
+Directory and file Structure
+****************************
+
+Pre-processor directives and macros
+***********************************
+
+Header Files
+************
+
+Variable Declarations, Qualifiers and Initializations
+*****************************************************
+
+Functions
+*********
+
+Statements
+**********
+
+Expressions
+***********
+
+Literals
+********
+
+Identifiers and Naming
+**********************
+
+Inline Assembly
+***************
+
+Compiler Directives, Intrinsic and Attributes
+**********************************************
+
+Assertion, Error Handling and Sanity checking
+*********************************************
+
+Comments, Documentation and License
+***********************************
+
+Coding Style and Formatting
+***************************
+
+Keyword Usage
+*************
+
+Libraries and Headers
+*********************


### PR DESCRIPTION
## PR Description

As discussed in #52 I'm introducing the coding guidelines in smaller steps to ease review and discussions.

This PR introduces the Coding Guidelines document in two steps:

- a small introduction to the purpose of the document and a description of how the guidelines shall be applied and its limitations;

- an introduction C Language guidelines and a scaffold for the various topics to be addressed in future PRs.

It should be useful to state what guidelines are being automatically checked/enforced, and by which tool. Any suggestions on how to do this?

Finally, I'm wondering if instead of merging to main, we should merge to an intermediate `wip/coding_guidelines` and then finally merge to main as when this reaches a satisfactory state.

### Type of change

- **feat**: introduces a new functionality
  - Logical unit: <coding_guidelines>

## Checklist:

- [x] The changes follows the documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst).
- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
