### PR TITLE
feat(ci): add ci submodule

### DIFF
--- a/.github/workflows/base-ci.yml
+++ b/.github/workflows/base-ci.yml
@@ -29,6 +29,9 @@ jobs:
     container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - run: |
           git config --global --add safe.directory $(realpath .)
           make spelling
@@ -48,4 +51,7 @@ jobs:
     container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - run: make html

--- a/.github/workflows/base-ci.yml
+++ b/.github/workflows/base-ci.yml
@@ -29,7 +29,7 @@ jobs:
     container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v2
-      - run: | 
+      - run: |
           git config --global --add safe.directory $(realpath .)
           make spelling
 
@@ -38,7 +38,7 @@ jobs:
     container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v2
-      - run: doc8 source/ --ignore D000
+      - run: make format
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/base-ci.yml
+++ b/.github/workflows/base-ci.yml
@@ -33,12 +33,15 @@ jobs:
           git config --global --add safe.directory $(realpath .)
           make spelling
 
-  format-check:
+  docformat:
     runs-on: ubuntu-latest
     container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v2
-      - run: make format
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - run: make rst-format
 
   build:
     runs-on: ubuntu-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bao-ci"]
+	path = bao-ci
+	url = git@github.com:bao-project/bao-ci.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bao-ci"]
-	path = bao-ci
+	path = ci
 	url = git@github.com:bao-project/bao-ci.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "bao-ci"]
+[submodule "ci"]
 	path = ci
 	url = git@github.com:bao-project/bao-ci.git

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Minimal makefile for Sphinx documentation
 #
-
+root_dir:=$(realpath .)
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?= -W -a
@@ -12,16 +12,17 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help format Makefile ci
+.PHONY: help
 
-# doc8 format checker
-# Checks the format of the reST sources.
-format:
-	@doc8 source/ --ignore D000
+# Instantiate CI rules
+include ci/ci.mk
+
+$(call ci, rstformat, $(SOURCEDIR))
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-ci: format html spelling
+ci: rst-format html spelling
+.PHONY: ci


### PR DESCRIPTION
## PR Description

This PR adds the bao-ci as submodule of the bao-docs repo. This is beneficial to allow the user to use the docker environment locally. 

### Type of change

- **feat**: introduces a new functionality
  - Logical unit: ci

## Checklist:

- [x] The changes follows the documentation guidelines described in [here](https://github.com/bao-project/bao-docs/blob/main/source/development/doc_guidelines.rst).
- [x] The changes generate no new warnings when building the project. If so, I have justified above.
- [x] I have run the CI checkers before submitting the PR to avoid unnecessary runs of the workflow.
