### PR TITLE
fix(config): correct off-by-one error in shmemlist_size

### DIFF
--- a/source/bao_hyp/user_manual/config.rst
+++ b/source/bao_hyp/user_manual/config.rst
@@ -30,16 +30,16 @@ for each list, it is necessary to specify the list size using the parameters ``s
             [0] = {/*shared memory config*/,},
             [1] = {/*shared memory config*/,},
             ...
-            [N] = {/*shared memory config*/,}
+            [N-1] = {/*shared memory config*/,}
         },
 
         // Guests Configuration
-        .vmlist_size = NUM_VMs,
+        .vmlist_size = N,
         .vmlist = {
             { /* VM 0 Config*/},
             { /* VM 1 Config*/},
             ...
-            { /* VM N Config*/},
+            { /* VM N-1 Config*/},
         }
     };
 


### PR DESCRIPTION
The example configuration defines `shmemlist_size` as N, but enumerates members [0] through [N], which actually results in N+1 items.

Adjust the value to use NUM_SHMEMs instead, ensuring consistency with how NUM_VMs is documented.