### PR TITLE
fix(glossary): add missing hyperlink for CI

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -48,8 +48,7 @@ exclude_patterns = [
     'introduction/*',
     'development/testing.rst',
     'development/coding_style.rst',
-    'bao_hyp/internals/index.rst',
-    'development/ci_pipeline.rst',]
+    'bao_hyp/internals/index.rst',]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/source/development/index.rst
+++ b/source/development/index.rst
@@ -4,6 +4,7 @@ Development Guidelines
 .. toctree::
    :maxdepth: 3
 
+   ci_pipeline
    code_documentation
    doc_guidelines
    contributing

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -12,7 +12,7 @@ Glossary
 
     CI
         Continuous Integration: process that automates the integration of new changes to the
-        repositories. More information here.
+        repositories. More information :ref:`here <ci>`.
 
     MISRA
         Set of software development guidelines for the C programming language developed by The


### PR DESCRIPTION
The CI term in the glossary was missing a hyperlink. Add the reference to the corresponding section.