### PR TITLE
fix(docutils): pin docutils version to <0.22

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 sphinxcontrib-spelling
 sphinx-tabs
 sphinx-rtd-theme
+docutils<0.22


### PR DESCRIPTION
This pull request makes a minor update to the documentation requirements by pinning the `docutils` dependency to a version below 0.22. This helps ensure compatibility with other Sphinx-related packages.